### PR TITLE
Deprecate use of ExpandedPyMISP

### DIFF
--- a/misp_client/misp.py
+++ b/misp_client/misp.py
@@ -2,8 +2,7 @@
 
 import logging
 
-# Year 2020 deprecation
-from pymisp import ExpandedPyMISP as PyMISP
+from pymisp import PyMISP
 from pymisp.exceptions import PyMISPError
 
 
@@ -14,8 +13,18 @@ class MISPClientConfigError(Exception):
     pass
 
 
+class MISPClientNoSuchInstanceError(Exception):
+    pass
+
+
 def init_misp(config, instance):
     "Return initialized PyMISP client"
+
+    # Handle invalid instance name
+    if not instance in config["instances"].keys():
+        raise MISPClientNoSuchInstanceError(
+            f"instance name {instance} does not exist in the configuration"
+        )
 
     # Initialize client with instance
     logger.debug("connecting to instance [%s]...", instance)
@@ -36,7 +45,7 @@ def init_misp(config, instance):
         )
     else:
         misp_ver = misp.misp_instance_version["version"]
-        logger.debug(
+        logger.info(
             "initialized client [%s] - server: MISP %s", instance, misp_ver
         )
 

--- a/misp_client/wrappers.py
+++ b/misp_client/wrappers.py
@@ -89,4 +89,4 @@ def get_event(config, args):
         print(json.dumps(event))
 
     # XXX Now process event
-    raise NotImplementedError("Plaintext dump is unimplemented, try JSON!")
+    raise NotImplementedError("Plaintext dump is not implemented. Use JSON.")

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="misp-client",
-    version="0.4.0",
+    version="0.4.1",
     description="Client interface for interacting with MISP instances",
     long_description=long_description,
     url="https://github.com/dspruell/misp-client",


### PR DESCRIPTION
- Deprecate use of ExpandedPyMISP and use PyMISP class
- Add exception MISPClientNoSuchInstanceError and support aborting when an unknown instance name is specified by the user
- Fix up logging levels by setting at the root logger correctly and setting the default log level to WARNING
- Add `--no-abort` option to allow the client to continue with other instances when one results in an error (log a warning instead of exiting with an error)

Resolve #3.